### PR TITLE
Update lerna.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.0.4",
+  "version": "independent",
   "repository": "https://github.com/kuldeepkeshwar/filbert-js"
 }


### PR DESCRIPTION
Since you're now using changeset and lerna is out of picture from versioning it's better to make the versioning strategy of lerna to `independent`. This also gives you the flexibility of not coupling the versions of packages and opt-out of lerna forcing that on you. [Read more here](https://github.com/lerna/lerna#how-it-works)