### PR TITLE
(core)add  @filbert-js/stylesheet in dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@filbert-js/browser-stylesheet": "^0.0.9",
     "@filbert-js/style-sheet-context": "^0.0.9",
+    "@filbert-js/stylesheet": "^0.0.7",
     "@filbert-js/css-ast": "^0.0.7",
     "@filbert-js/css-parser": "^0.0.8",
     "@filbert-js/types": "^0.0.6",
@@ -28,6 +29,7 @@
     "@filbert-js/browser-stylesheet": "^0.0.9",
     "@filbert-js/style-sheet-context": "^0.0.9",
     "@filbert-js/css-ast": "^0.0.7",
+    "@filbert-js/stylesheet": "^0.0.7",
     "@filbert-js/css-parser": "^0.0.8",
     "@filbert-js/types": "^0.0.6",
     "@filbert-js/theming": "^0.0.6",


### PR DESCRIPTION
`import { styled } from "@filbert-js/core";`
importing only `@filbert-js/core`(`v0.0.12`) package throws error 
```sh
DependencyNotFoundError
Could not find dependency: '@filbert-js/stylesheet' relative to '/node_modules/@filbert-js/browser-stylesheet/dist/index.es.js'
```
Workaround : adding `@filbert-js/stylesheet` explicitly fixes the issue. 
Fix: Add `@filbert-js/stylesheet`  to dependency list of `@filbert-js/core`